### PR TITLE
Make blanket implementations opt-in rather than opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ public_items ./target/doc/your_library.json
 
 # Example: Letting the library list its own public items
 
-Note that we pass `--omit-blanket-implementations` in this case since blanket implementations such as `impl<T> Borrow<T> for T` are usually not of interest.
 ```txt
 % RUSTDOCFLAGS='-Z unstable-options --output-format json' cargo +nightly doc --lib --no-deps
-% public_items --omit-blanket-implementations ./target/doc/public_items.json
+% public_items ./target/doc/public_items.json
 pub enum public_items::Error
 pub enum variant public_items::Error::SerdeJsonError(serde_json::Error)
 pub fn public_items::Error::fmt(&self, __formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
@@ -50,6 +49,12 @@ pub type public_items::Result<T> = std::result::Result<T, Error>
 ```
 
 Tip: By writing the public API to a file for two different versions of your library, you can diff your public API across versions.
+
+# Blanket implementations
+
+By default, blanket implementations such as `impl<T> Any for T`, `impl<T> Borrow<T> for T`, and `impl<T, U> Into<U> for T where U: From<T>` are omitted from the list of public items of a crate. For the vast majority of use cases, blanket implementations are not of interest, and just creates noise.
+
+If you want to include items of blanket implementations in the output, set `Options::with_blanket_implementations` to true if you use the library, or pass `--with-blanket-implementations` if you use the `public_items` binary utility.
 
 # Target audience
 

--- a/src/bin/public_items/main.rs
+++ b/src/bin/public_items/main.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
         print_usage()?;
     } else {
         let mut options = Options::default();
-        options.omit_blanket_implementations = flag_raised("--omit-blanket-implementations");
+        options.with_blanket_implementations = flag_raised("--with-blanket-implementations");
         print_public_api_items(Path::new(&last_arg.unwrap()), options)?;
     }
 

--- a/src/implementation/item_iterator.rs
+++ b/src/implementation/item_iterator.rs
@@ -124,7 +124,7 @@ fn find_all_impls(crate_: &Crate, options: Options) -> Impls {
                 ..
             } = impl_
             {
-                let omit = options.omit_blanket_implementations && matches!(blanket_impl, Some(_));
+                let omit = !options.with_blanket_implementations && matches!(blanket_impl, Some(_));
                 if !omit {
                     impls.entry(id).or_insert_with(Vec::new).push(impl_);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,12 +32,12 @@ pub struct PublicItem {
 pub struct Options {
     /// If `true`, items part of blanket implementations such as `impl<T> Any
     /// for T`, `impl<T> Borrow<T> for T`, and `impl<T, U> Into<U> for T where
-    /// U: From<T>` are omitted from the list of public items of a crate.
+    /// U: From<T>` are included in the list of public items of a crate.
     ///
-    /// The default value is `false` since the point of this library is to list
-    /// all public items of a crate, and blanket implementations are formally
-    /// part of the public API of a crate.
-    pub omit_blanket_implementations: bool,
+    /// The default value is `false` since the the vast majority of users will
+    /// find the presence of these items to just constitute noise, even if they
+    /// formally are part of the public API of a crate.
+    pub with_blanket_implementations: bool,
 }
 
 /// Implementation that allows passing `Options::default()` for the `options`
@@ -45,7 +45,7 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Self {
-            omit_blanket_implementations: false,
+            with_blanket_implementations: false,
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,7 @@ use public_items::Options;
 
 #[test]
 fn bat_v0_19_0() {
-    assert_public_items(
+    assert_public_items_with_blanket_implementations(
         include_str!("./rustdoc_json/bat-v0.19.0.json"),
         include_str!("./rustdoc_json/bat-v0.19.0-expected.txt"),
     );
@@ -11,7 +11,7 @@ fn bat_v0_19_0() {
 
 #[test]
 fn public_items_git_omit_blanket_implementations() {
-    assert_public_items_omit_blanket_implementations(
+    assert_public_items(
         include_str!("./rustdoc_json/public_items-git.json"),
         include_str!("./rustdoc_json/public_items-git-expected.txt"),
     );
@@ -19,7 +19,7 @@ fn public_items_git_omit_blanket_implementations() {
 
 #[test]
 fn syntect_v4_6_0() {
-    assert_public_items(
+    assert_public_items_with_blanket_implementations(
         include_str!("./rustdoc_json/syntect-v4.6.0.json"),
         include_str!("./rustdoc_json/syntect-v4.6.0-expected.txt"),
     );
@@ -27,7 +27,7 @@ fn syntect_v4_6_0() {
 
 #[test]
 fn thiserror_v1_0_30() {
-    assert_public_items(
+    assert_public_items_with_blanket_implementations(
         include_str!("./rustdoc_json/thiserror-1.0.30.json"),
         include_str!("./rustdoc_json/thiserror-1.0.30-expected.txt"),
     );
@@ -37,17 +37,17 @@ fn assert_public_items(json: &str, expected: &str) {
     assert_public_items_impl(json, expected, false);
 }
 
-fn assert_public_items_omit_blanket_implementations(json: &str, expected: &str) {
+fn assert_public_items_with_blanket_implementations(json: &str, expected: &str) {
     assert_public_items_impl(json, expected, true);
 }
 
 fn assert_public_items_impl(
     rustdoc_json_str: &str,
     expected_output: &str,
-    omit_blanket_implementations: bool,
+    with_blanket_implementations: bool,
 ) {
     let mut options = Options::default();
-    options.omit_blanket_implementations = omit_blanket_implementations;
+    options.with_blanket_implementations = with_blanket_implementations;
 
     let actual: Vec<String> =
         public_items::sorted_public_items_from_rustdoc_json_str(rustdoc_json_str, options)


### PR DESCRIPTION
The vast majority of users will not be interested in items from blanket
implementations.