### PR TITLE
PublicItem: Stop deriving Hash

### DIFF
--- a/src/item_iterator.rs
+++ b/src/item_iterator.rs
@@ -175,7 +175,7 @@ fn intermediate_public_item_to_public_item(
 
 /// To hide implementation details as much as possible from people who casually
 /// skims over the code in our lib.rs
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PublicItemInner {
     /// The "pub struct/fn/..." part of an item.
     pub(crate) prefix: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub use error::Result;
 /// of the public API of a crate. Implements `Display` so it can be printed. It
 /// also implements [`Ord`], but how items are ordered are not stable yet, and
 /// will change in later versions.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PublicItem(item_iterator::PublicItemInner);
 
 /// One of the basic uses cases is printing a sorted `Vec` of `PublicItem`s. So


### PR DESCRIPTION
I forgot to remove `Hash` on `PublicItem` in https://github.com/Enselic/public_items/pull/50.

CC @douweschulte since this change could be relevant if you want to experiment with putting  `syn` inside of `PublicItem`
