### PR TITLE
README: Mention MINIMUM_RUSTDOC_JSON_VERSION in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ List public items (the public API) of Rust library crates by analyzing their rus
 The library comes with a thin bin wrapper that can be used to explore the capabilities of this library.
 
 ```bash
-# Install the thin bin wrapper
-% cargo install public_items
+# Build and install the thin bin wrapper with the regular stable Rust toolchain
+cargo install public_items
 
-# Install a recent version of nightly so that rustdoc JSON can be generated
-% rustup install nightly
+# Install nightly-2022-03-14 or later so you can build up-to-date rustdoc JSON files
+rustup install nightly
 ```
 
 ## List public items

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ You might want the convenient `cargo public-items` wrapper for this library. See
 
 # public_items
 
-List public items (the public API) of Rust library crates by analyzing the rustdoc JSON of the crates. Also supports diffing the public API between releases and commits.
+List public items (the public API) of Rust library crates by analyzing their rustdoc JSON. Also supports diffing the public API between releases and commits to e.g. help find breaking API changes or semver violations.
 
 # Usage
 

--- a/tests/readme_tests.rs
+++ b/tests/readme_tests.rs
@@ -1,0 +1,11 @@
+use public_items::MINIMUM_RUSTDOC_JSON_VERSION;
+
+#[test]
+fn installation_instructions_mentions_minimum_rustdoc_json_version() {
+    let readme = include_str!("../README.md");
+    let expected_installation_instruction = format!(
+        "# Install {} or later so you can build up-to-date rustdoc JSON files",
+        MINIMUM_RUSTDOC_JSON_VERSION
+    );
+    assert!(readme.contains(&expected_installation_instruction));
+}


### PR DESCRIPTION
And add a test so we don't forget to update the instruction when we bump MINIMUM_RUSTDOC_JSON_VERSION next time.