### PR TITLE
CI: Make 'code coverage' job work again

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,4 +53,4 @@ jobs:
         profile: minimal
         components: llvm-tools-preview
     - run: cargo install cargo-llvm-cov
-    - run: cargo llvm-cov
+    - run: cargo +nightly llvm-cov


### PR DESCRIPTION
We currently get an error:
```
error: cargo-llvm-cov requires rustc 1.60+; consider updating toolchain (`rustup update`)
                 or using nightly toolchain (`cargo +nightly llvm-cov`)
```