### PR TITLE
Rename project to public-api

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
     branches: [ main ]
   # The purpose of running every night is to detect when a change to
   # https://github.com/rust-lang/rust/tree/master/src/rustdoc-json-types
-  # requires that we release a new version of public_items to be compatible with
+  # requires that we release a new version of public-api to be compatible with
   # the latest nightly toolchain
   schedule:
     - cron: '33 3 * * *'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "public_items"
+name = "public-api"
 version = "0.8.0"
 dependencies = [
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-description = "List and diff public items (the public API) of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
-documentation = "https://docs.rs/public_items"
+description = "List and diff the public API of Rust library crates. Relies on rustdoc JSON output from the nightly toolchain."
+documentation = "https://docs.rs/public-api"
 edition = "2021"
-homepage = "https://github.com/Enselic/public_items"
+homepage = "https://github.com/Enselic/public-api"
 license = "MIT"
-name = "public_items"
-repository = "https://github.com/Enselic/public_items"
+name = "public-api"
+repository = "https://github.com/Enselic/public-api"
 
-# Also update https://github.com/Enselic/public_items#compatibility-matrix
+# Also update https://github.com/Enselic/public-api#compatibility-matrix
 version = "0.8.0"
 
 [dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) by contributors to https://github.com/Enselic/public_items
+Copyright (c) by contributors to https://github.com/Enselic/public-api
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 You might want the convenient `cargo public-api` wrapper for this library. See https://github.com/Enselic/cargo-public-api.
 
-# public_items
+# public-api
 
-List public items (the public API) of Rust library crates by analyzing their rustdoc JSON. Also supports diffing the public API between releases and commits to e.g. help find breaking API changes or semver violations.
+List and diff the public API of Rust library crates by analyzing their rustdoc JSON. Diffing the public API between releases and commits can help you find breaking API changes and semver violations.
 
 # Usage
 
@@ -12,13 +12,13 @@ The library comes with a thin bin wrapper that can be used to explore the capabi
 
 ```bash
 # Build and install the thin bin wrapper with the a recent stable Rust toolchain
-cargo install public_items
+cargo install public-api
 
 # Install nightly-2022-03-14 or later so you can build up-to-date rustdoc JSON files
 rustup install nightly
 ```
 
-## List public items
+## List public API
 
 To list all items that form the public API of your Rust library:
 
@@ -28,39 +28,39 @@ To list all items that form the public API of your Rust library:
 % RUSTDOCFLAGS='-Z unstable-options --output-format json' cargo +nightly doc --lib --no-deps
 
 # List all items in the public API of your Rust library
-% public_items ./target/doc/your_library.json
-pub mod public_items
-pub fn public_items::Options::clone(&self) -> Options
-pub fn public_items::Options::default() -> Self
-pub fn public_items::PublicItem::clone(&self) -> PublicItem
-pub fn public_items::public_items_from_rustdoc_json_str(rustdoc_json_str: &str, options: Options) -> Result<Vec<PublicItem>>
-pub struct public_items::Options
-pub struct public_items::PublicItem
-pub struct field public_items::Options::sorted: bool
-pub struct field public_items::Options::with_blanket_implementations: bool
+% public-api ./target/doc/your_library.json
+pub mod public_api
+pub fn public_api::Options::clone(&self) -> Options
+pub fn public_api::Options::default() -> Self
+pub fn public_api::PublicItem::clone(&self) -> PublicItem
+pub fn public_api::public_api_from_rustdoc_json_str(rustdoc_json_str: &str, options: Options) -> Result<Vec<PublicItem>>
+pub struct public_api::Options
+pub struct public_api::PublicItem
+pub struct field public_api::Options::sorted: bool
+pub struct field public_api::Options::with_blanket_implementations: bool
 ...
 ```
 
-## Diff public items
+## Diff public API
 
 It is frequently of interest to know how the public API of a crate has changed. You can find this out by doing a diff between different versions of the same library. Again, [`cargo public-api`](https://github.com/Enselic/cargo-public-api) makes this more convenient, but it is straightforward enough without it.
 
 ```bash
 # Generate two different rustdoc JSON files for two different versions of your library
 # and then pass both files to the bin to make it print the public API diff
-% public_items ./target/doc/your_library.old.json  ./target/doc/your_library.json
+% public-api ./target/doc/your_library.old.json  ./target/doc/your_library.json
 Removed:
 (nothing)
 
 Changed:
--pub fn public_items::sorted_public_items_from_rustdoc_json_str(rustdoc_json_str: &str) -> Result<Vec<PublicItem>>
-+pub fn public_items::sorted_public_items_from_rustdoc_json_str(rustdoc_json_str: &str, options: Options) -> Result<Vec<PublicItem>>
+-pub fn public_api::sorted_public_api_from_rustdoc_json_str(rustdoc_json_str: &str) -> Result<Vec<PublicItem>>
++pub fn public_api::sorted_public_api_from_rustdoc_json_str(rustdoc_json_str: &str, options: Options) -> Result<Vec<PublicItem>>
 
 Added:
-+pub fn public_items::Options::clone(&self) -> Options
-+pub fn public_items::Options::default() -> Self
-+pub struct public_items::Options
-+pub struct field public_items::Options::with_blanket_implementations: bool
++pub fn public_api::Options::clone(&self) -> Options
++pub fn public_api::Options::default() -> Self
++pub struct public_api::Options
++pub struct field public_api::Options::with_blanket_implementations: bool
 ```
 
 # Expected output
@@ -74,7 +74,7 @@ where
     P: AsRef<Path>,
 ```
 
-and `public_items` represent this item in the following manner:
+and `public-api` represent this item in the following manner:
 
 ```
 pub fn bat::PrettyPrinter::input_files<I, P>(&mut self, paths: I) -> &mut Self where I: IntoIterator<Item = P>, P: AsRef<Path>
@@ -91,11 +91,11 @@ pub fn bat::PrettyPrinter::input_files<I, P>(&mut self, paths: I) -> &mut Self w
 
 By default, blanket implementations such as `impl<T> Any for T`, `impl<T> Borrow<T> for T`, and `impl<T, U> Into<U> for T where U: From<T>` are omitted from the list of public items of a crate. For the vast majority of use cases, blanket implementations are not of interest, and just creates noise.
 
-If you want to include items of blanket implementations in the output, set [`Options::with_blanket_implementations`](https://docs.rs/public_items/latest/public_items/struct.Options.html#structfield.with_blanket_implementations) to true if you use the library, or pass `--with-blanket-implementations` to `public_items`.
+If you want to include items of blanket implementations in the output, set [`Options::with_blanket_implementations`](https://docs.rs/public-api/latest/public_api/struct.Options.html#structfield.with_blanket_implementations) to true if you use the library, or pass `--with-blanket-implementations` to `public_api`.
 
 # Library documentation
 
-Documentation can be found at [docs.rs](https://docs.rs/public_items/latest/public_items/) as usual. There are also some simple [examples](https://github.com/Enselic/public_items/tree/main/examples) on how to use the library. The code for the [thin bin wrapper](https://github.com/Enselic/public_items/blob/main/src/main.rs) might also be of interest.
+Documentation can be found at [docs.rs](https://docs.rs/public-api/latest/public-api/) as usual. There are also some simple [examples](https://github.com/Enselic/public-api/tree/main/examples) on how to use the library. The code for the [thin bin wrapper](https://github.com/Enselic/public-api/blob/main/src/main.rs) might also be of interest.
 
 # Target audience
 
@@ -103,12 +103,12 @@ Maintainers of Rust libraries that want to keep track of changes to their public
 
 # Limitations
 
-See [`[limitation]`](https://github.com/Enselic/public_items/labels/limitation)
+See [`[limitation]`](https://github.com/Enselic/public-api/labels/limitation)
 labeled issues.
 
 # Compatibility matrix
 
-| public_items  | Understands the rustdoc JSON output of  |
+| public-api    | Understands the rustdoc JSON output of  |
 | ------------- | --------------------------------------- |
 | v0.8.x        | nightly-2022-03-14 —                    |
 | v0.5.x        | nightly-2022-02-23 — nightly-2022-03-13 |

--- a/examples/diff_public_api.rs
+++ b/examples/diff_public_api.rs
@@ -1,16 +1,16 @@
 use std::{error::Error, fs::read_to_string};
 
-use public_items::{diff::PublicItemsDiff, public_items_from_rustdoc_json_str, Options};
+use public_api::{diff::PublicItemsDiff, public_api_from_rustdoc_json_str, Options};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let options = Options::default();
 
-    let old = public_items_from_rustdoc_json_str(
+    let old = public_api_from_rustdoc_json_str(
         &read_to_string("./tests/rustdoc-json/example_api-v0.1.0.json")?,
         options,
     )?;
 
-    let new = public_items_from_rustdoc_json_str(
+    let new = public_api_from_rustdoc_json_str(
         &read_to_string("./tests/rustdoc-json/example_api-v0.2.0.json")?,
         options,
     )?;

--- a/examples/list_public_api.rs
+++ b/examples/list_public_api.rs
@@ -1,14 +1,14 @@
 use std::{error::Error, fs::read_to_string};
 
-use public_items::{public_items_from_rustdoc_json_str, Options};
+use public_api::{public_api_from_rustdoc_json_str, Options};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let public_items = public_items_from_rustdoc_json_str(
+    let public_api = public_api_from_rustdoc_json_str(
         &read_to_string("./tests/rustdoc-json/example_api-v0.2.0.json")?,
         Options::default(),
     )?;
 
-    for public_item in public_items {
+    for public_item in public_api {
         println!("{}", public_item);
     }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -19,7 +19,7 @@ pub struct ChangedPublicItem {
 /// The return value of [`Self::between`]. To quickly get a sense of what it
 /// contains, you can pretty-print it:
 /// ```txt
-/// println!("{:#?}", public_items_diff);
+/// println!("{:#?}", public_api_diff);
 /// ```
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -43,7 +43,7 @@ impl PublicItemsDiff {
     /// Allows you to diff the public API between two arbitrary versions of a
     /// library, e.g. different releases. The input parameters `old` and `new`
     /// is the output of two different invocations of
-    /// [`crate::public_items_from_rustdoc_json_str`].
+    /// [`crate::public_api_from_rustdoc_json_str`].
     #[must_use]
     pub fn between(old_items: Vec<PublicItem>, new_items: Vec<PublicItem>) -> Self {
         let mut old_sorted = old_items;

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,5 +11,5 @@ pub enum Error {
     SerdeJsonError(#[from] serde_json::Error),
 }
 
-/// Shorthand for [`std::result::Result<T, public_items::Error>`].
+/// Shorthand for [`std::result::Result<T, public_api::Error>`].
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/item_iterator.rs
+++ b/src/item_iterator.rs
@@ -155,7 +155,7 @@ fn items_in_container(item: &Item) -> Option<&Vec<Id>> {
     }
 }
 
-pub fn public_items_in_crate(
+pub fn public_api_in_crate(
     crate_: &Crate,
     options: Options,
 ) -> impl Iterator<Item = PublicItem> + '_ {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,33 +1,37 @@
-//! This library gives you a list of all public items (otherwise known as the
-//! public API) of a library crate. As input to the library, a special output
-//! format from `cargo doc` is used, which goes by the name **rustdoc JSON**.
-//! Currently, only `cargo doc` from the Nightly toolchain can produce **rustdoc
-//! JSON** for a library. You build **rustdoc JSON** like this:
+//! This library gives you a the public API of a library crate, in the form of a
+//! list of public items in the crate. Public items are items that other crates
+//! can use.
+//!
+//! As input to the library, a special output format from `cargo doc` is used,
+//! which goes by the name **rustdoc JSON**. Currently, only `cargo doc` from
+//! the Nightly toolchain can produce **rustdoc JSON** for a library. You build
+//! **rustdoc JSON** like this:
 //!
 //! ```bash
 //! RUSTDOCFLAGS='-Z unstable-options --output-format json' cargo +nightly doc --lib --no-deps
 //! ```
 //!
-//! The main entry point to the library is
-//! [`public_items_from_rustdoc_json_str`], so please read its documentation.
+//! The main entry point to the library is [`public_api_from_rustdoc_json_str`],
+//! so please read its documentation.
 //!
 //! # Examples
 //!
-//! The two main use cases are listing public items, and diffing public items.
+//! The two main use cases are listing the public API and diffing different
+//! versions of the same public APIs.
 //!
 //! ## List all public items of a crate (the public API)
 //! ```
-#![doc = include_str!("../examples/list_public_items.rs")]
+#![doc = include_str!("../examples/list_public_api.rs")]
 //! ```
 //!
 //! ## Diff two versions of a public API
 //! ```
-#![doc = include_str!("../examples/diff_public_items.rs")]
+#![doc = include_str!("../examples/diff_public_api.rs")]
 //! ```
 //!
 //! The most comprehensive example code on how to use the library can be found
 //! in the thin binary wrapper around the library, see
-//! <https://github.com/Enselic/public_items/blob/main/src/main.rs>.
+//! <https://github.com/Enselic/public-api/blob/main/src/main.rs>.
 
 #![deny(missing_docs)]
 #![deny(clippy::all, clippy::pedantic)]
@@ -55,7 +59,7 @@ pub use item_iterator::PublicItem;
 /// nightly or later, you should be fine.
 pub const MINIMUM_RUSTDOC_JSON_VERSION: &str = "nightly-2022-03-14";
 
-/// Contains various options that you can pass to [`public_items_from_rustdoc_json_str`].
+/// Contains various options that you can pass to [`public_api_from_rustdoc_json_str`].
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive] // More options are likely to be added in the future
 pub struct Options {
@@ -82,7 +86,7 @@ pub struct Options {
 /// `#[non_exhaustive]`):
 ///
 /// ```
-/// # use public_items::Options;
+/// # use public_api::Options;
 /// let mut options = Options::default();
 /// options.sorted = true;
 /// // ...
@@ -118,17 +122,17 @@ impl Default for Options {
 /// # Errors
 ///
 /// E.g. if the JSON is invalid.
-pub fn public_items_from_rustdoc_json_str(
+pub fn public_api_from_rustdoc_json_str(
     rustdoc_json_str: &str,
     options: Options,
 ) -> Result<Vec<PublicItem>> {
     let crate_: rustdoc_types::Crate = serde_json::from_str(rustdoc_json_str)?;
 
-    let mut public_items: Vec<_> = item_iterator::public_items_in_crate(&crate_, options).collect();
+    let mut public_api: Vec<_> = item_iterator::public_api_in_crate(&crate_, options).collect();
 
     if options.sorted {
-        public_items.sort();
+        public_api.sort();
     }
 
-    Ok(public_items)
+    Ok(public_api)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use std::io::{stdout, Write};
 use std::path::{Path, PathBuf};
 
-use public_items::diff::PublicItemsDiff;
-use public_items::{public_items_from_rustdoc_json_str, Options, MINIMUM_RUSTDOC_JSON_VERSION};
+use public_api::diff::PublicItemsDiff;
+use public_api::{public_api_from_rustdoc_json_str, Options, MINIMUM_RUSTDOC_JSON_VERSION};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -25,32 +25,32 @@ fn main() -> Result<()> {
         print_usage()?;
     } else if files.len() == 1 {
         let path = &files[0];
-        print_public_items(path, options)?;
+        print_public_api(path, options)?;
     } else if files.len() == 2 {
         let old = &files[0];
         let new = &files[1];
-        print_public_items_diff(old, new, options)?;
+        print_public_api_diff(old, new, options)?;
     }
 
     Ok(())
 }
 
-fn print_public_items(path: &Path, options: Options) -> Result<()> {
+fn print_public_api(path: &Path, options: Options) -> Result<()> {
     let json = &std::fs::read_to_string(path)?;
 
-    for public_item in public_items_from_rustdoc_json_str(json, options)? {
+    for public_item in public_api_from_rustdoc_json_str(json, options)? {
         writeln!(std::io::stdout(), "{}", public_item)?;
     }
 
     Ok(())
 }
 
-fn print_public_items_diff(old: &Path, new: &Path, options: Options) -> Result<()> {
+fn print_public_api_diff(old: &Path, new: &Path, options: Options) -> Result<()> {
     let old_json = std::fs::read_to_string(old)?;
-    let old_items = public_items_from_rustdoc_json_str(&old_json, options)?;
+    let old_items = public_api_from_rustdoc_json_str(&old_json, options)?;
 
     let new_json = std::fs::read_to_string(new)?;
-    let new_items = public_items_from_rustdoc_json_str(&new_json, options)?;
+    let new_items = public_api_from_rustdoc_json_str(&new_json, options)?;
 
     let diff = PublicItemsDiff::between(old_items, new_items);
     print_diff_with_headers(&diff, &mut stdout(), "Removed:", "Changed:", "Added:")?;
@@ -99,7 +99,7 @@ fn print_items_with_header<W: std::io::Write, T>(
 fn print_usage() -> std::io::Result<()> {
     writeln!(
         stdout(),
-        "public_items v{}
+        "public-api v{}
 
 Requires at least {}.
 
@@ -109,7 +109,7 @@ automatically.
 
 If you insist of using this low-level utility and thin wrapper, you run it like this:
 
-    public_items <RUSTDOC_JSON_FILE>
+    public-api <RUSTDOC_JSON_FILE>
 
 where RUSTDOC_JSON_FILE is the path to the output of
 
@@ -122,7 +122,7 @@ which you can find in
 To diff the public API between two commits, you generate one rustdoc JSON file for each
 commit and then pass the path of both files to this utility:
 
-    public_items <RUSTDOC_JSON_FILE_OLD> <RUSTDOC_JSON_FILE_NEW>
+    public-api <RUSTDOC_JSON_FILE_OLD> <RUSTDOC_JSON_FILE_NEW>
 
 To include blanket implementations, pass --with-blanket-implementations.
 ",

--- a/tests/bin_tests.rs
+++ b/tests/bin_tests.rs
@@ -1,5 +1,5 @@
 use assert_cmd::Command;
-use public_items::MINIMUM_RUSTDOC_JSON_VERSION;
+use public_api::MINIMUM_RUSTDOC_JSON_VERSION;
 
 mod utils;
 use serial_test::serial;
@@ -7,7 +7,7 @@ use utils::rustdoc_json_path_for_crate;
 
 #[test]
 #[serial] // Writing and reading rustdoc JSON to/from file-system; must run one test at a time
-fn print_public_items() {
+fn print_public_api() {
     cmd_with_rustdoc_json_args(&["./tests/crates/comprehensive_api"], |mut cmd| {
         cmd.assert()
             .stdout(include_str!("./expected-output/comprehensive_api.txt"))
@@ -18,7 +18,7 @@ fn print_public_items() {
 
 #[test]
 #[serial]
-fn print_public_items_with_blanket_implementations() {
+fn print_public_api_with_blanket_implementations() {
     cmd_with_rustdoc_json_args(&["./tests/crates/example_api-v0.2.0"], |mut cmd| {
         cmd.arg("--with-blanket-implementations");
         cmd.assert()
@@ -122,7 +122,7 @@ Added:
 
 #[test]
 fn short_help() {
-    let mut cmd = Command::cargo_bin("public_items").unwrap();
+    let mut cmd = Command::cargo_bin("public-api").unwrap();
     cmd.arg("-h");
     cmd.assert()
         .stdout(expected_help_text())
@@ -132,7 +132,7 @@ fn short_help() {
 
 #[test]
 fn long_help() {
-    let mut cmd = Command::cargo_bin("public_items").unwrap();
+    let mut cmd = Command::cargo_bin("public-api").unwrap();
     cmd.arg("--help");
     cmd.assert()
         .stdout(expected_help_text())
@@ -142,7 +142,7 @@ fn long_help() {
 
 #[test]
 fn no_args_shows_help() {
-    let mut cmd = Command::cargo_bin("public_items").unwrap();
+    let mut cmd = Command::cargo_bin("public-api").unwrap();
     cmd.assert()
         .stdout(expected_help_text())
         .stderr("")
@@ -151,7 +151,7 @@ fn no_args_shows_help() {
 
 #[test]
 fn too_many_args_shows_help() {
-    let mut cmd = Command::cargo_bin("public_items").unwrap();
+    let mut cmd = Command::cargo_bin("public-api").unwrap();
     cmd.args(&["too", "many", "args"]);
     cmd.assert()
         .stdout(expected_help_text())
@@ -161,7 +161,7 @@ fn too_many_args_shows_help() {
 
 fn expected_help_text() -> String {
     format!(
-        "public_items v{}
+        "public-api v{}
 
 Requires at least {}.
 
@@ -171,7 +171,7 @@ automatically.
 
 If you insist of using this low-level utility and thin wrapper, you run it like this:
 
-    public_items <RUSTDOC_JSON_FILE>
+    public-api <RUSTDOC_JSON_FILE>
 
 where RUSTDOC_JSON_FILE is the path to the output of
 
@@ -184,7 +184,7 @@ which you can find in
 To diff the public API between two commits, you generate one rustdoc JSON file for each
 commit and then pass the path of both files to this utility:
 
-    public_items <RUSTDOC_JSON_FILE_OLD> <RUSTDOC_JSON_FILE_NEW>
+    public-api <RUSTDOC_JSON_FILE_OLD> <RUSTDOC_JSON_FILE_NEW>
 
 To include blanket implementations, pass --with-blanket-implementations.
 
@@ -194,11 +194,11 @@ To include blanket implementations, pass --with-blanket-implementations.
     )
 }
 
-/// Helper to setup a `public_items` [`Command`] with rustdoc JSON path args
+/// Helper to setup a `public-api` [`Command`] with rustdoc JSON path args
 /// corresponding to the given crates. Use `final_steps` to specify the
 /// remaining steps in the test.
 fn cmd_with_rustdoc_json_args(crates: &[&str], final_steps: impl FnOnce(Command)) {
-    let mut cmd = Command::cargo_bin("public_items").unwrap();
+    let mut cmd = Command::cargo_bin("public-api").unwrap();
 
     for crate_ in crates {
         cmd.arg(rustdoc_json_path_for_crate(crate_));

--- a/tests/readme_tests.rs
+++ b/tests/readme_tests.rs
@@ -1,4 +1,4 @@
-use public_items::MINIMUM_RUSTDOC_JSON_VERSION;
+use public_api::MINIMUM_RUSTDOC_JSON_VERSION;
 
 #[test]
 fn installation_instructions_mentions_minimum_rustdoc_json_version() {


### PR DESCRIPTION
For now the our public API does a simple rename from public_items to public_api. We are likely to restructure the API later, e.g. turning it into a tree rather than a list.

Closes #64